### PR TITLE
Maven-217: Interpolation of system properties not working for pom imports

### DIFF
--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractToolsLiferayMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractToolsLiferayMojo.java
@@ -623,6 +623,11 @@ public abstract class AbstractToolsLiferayMojo extends AbstractLiferayMojo {
 			activeProfileIds.add(activeProfile);
 		}
 
+		projectBuildingRequest.setUserProperties(
+				mavenExecutionRequest.getUserProperties());
+		projectBuildingRequest.setSystemProperties(
+				mavenExecutionRequest.getSystemProperties());
+
 		projectBuildingRequest.setActiveProfileIds(activeProfileIds);
 		projectBuildingRequest.setProfiles(
 			mavenExecutionRequest.getProfiles());


### PR DESCRIPTION
This pull request with fix some interpolation problems with system properties in dependent maven projects.

Please have a look at https://issues.liferay.com/browse/MAVEN-217 for more information and for an example.
